### PR TITLE
Fix deprecation warning: use keyword arguments in define-minor-mode for Emacs compatibility

### DIFF
--- a/company-statistics.el
+++ b/company-statistics.el
@@ -346,7 +346,9 @@ preserved automatically between Emacs sessions in the default
 configuration.  You can customize this behavior with
 `company-statistics-auto-save', `company-statistics-auto-restore' and
 `company-statistics-file'."
-  nil nil nil
+  :init-value nil
+  :lighter nil
+  :keymap nil
   :global t
   (if company-statistics-mode
       (progn


### PR DESCRIPTION
## Fix deprecation warning for modern Emacs versions

This PR replaces the deprecated positional arguments in `define-minor-mode` with keyword arguments to fix compatibility with modern Emacs versions.

### Changes:
- **company-statistics.el**: Replace positional arguments with keyword arguments in `define-minor-mode`
- Use `:init-value`, `:lighter`, and `:keymap` instead of positional args
- Maintains exact same functionality while using modern syntax

### Why:
- Positional arguments in `define-minor-mode` are deprecated in modern Emacs
- Keyword arguments are the recommended approach for better clarity and compatibility
- This eliminates deprecation warnings in modern Emacs versions
- Ensures the package works correctly with future Emacs releases

### Technical Details:
- **Before**: `(define-minor-mode company-statistics-mode ... nil nil nil :global t ...)`
- **After**: `(define-minor-mode company-statistics-mode ... :init-value nil :lighter nil :keymap nil :global t ...)`

### Testing:
- ✅ Package loads successfully without deprecation warnings
- ✅ All functionality preserved
- ✅ Compatible with modern Emacs versions
- ✅ No breaking changes to existing behavior

This fix ensures company-statistics continues to work seamlessly with modern Emacs versions while eliminating deprecation warnings.